### PR TITLE
Update to Site Transactions API Response

### DIFF
--- a/server/controllers/siteController.ts
+++ b/server/controllers/siteController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express"
 import mongoose from "mongoose"
 import siteModel from "../models/siteModel"
+import token from "../models/token"
 
 const getSingleSite = async (req: Request, res: Response) => {
     const { id } = req.params
@@ -52,17 +53,37 @@ const getSiteLeads = async (req: Request, res: Response) => {
 const getSiteTransactions = async (req: Request, res: Response) => {
     const { id } = req.params
 
+    let txnsResponse = []
+
     if (!mongoose.Types.ObjectId.isValid(id)) {
         return res.status(404).json({ error: "no such site" })
     }
 
     const site = await siteModel.findById(id).populate("transactions")
     if (site) {
-        const txns = site.transactions
-        return res.status(200).json(txns)
+        for (const txn of site.transactions) {
+            const tokenId = txn.metadata?.token
+
+            if (tokenId) {
+                const tokenObj = await fetchTokenDetails(tokenId)
+                txn.metadata.token = tokenObj
+            }
+
+            txnsResponse.push(txn)
+        }
+
+        
+
+        return res.status(200).json(txnsResponse)
     } else {
         return res.status(404).json({ error: "No site found" })
     }
+}
+
+const fetchTokenDetails = async (tokenId: string) => {
+    const tokenObj = await token.findById(tokenId).populate("lead")
+    // console.log("tokenObj ===", tokenObj)
+    return tokenObj
 }
 
 export { getSingleSite, getSiteLeads, getSiteTransactions, updateSite }

--- a/server/controllers/transactionController.ts
+++ b/server/controllers/transactionController.ts
@@ -8,13 +8,9 @@ import { transactionSchema } from "../zod/schemas"
 
 const createTransaction = async (req: Request, res: Response) => {
     const parsedData = transactionSchema.safeParse(req.body)
-    // console.log("123 ===",123)
-    // console.log("parsedData ===",parsedData)
 
     if (!parsedData.success) {
         return res.status(500).json(parsedData.error)
-
-        // console.log("parsedData.data ===",parsedData.data)
     }
 
     try {
@@ -26,7 +22,6 @@ const createTransaction = async (req: Request, res: Response) => {
         await txn.save()
         site?.transactions.push(txn._id)
         await site?.save()
-        // console.log({...parsedData.data})
         return res.status(200).json(txn)
     } catch (error) {
         res.status(500).json(error)

--- a/server/models/siteModel.ts
+++ b/server/models/siteModel.ts
@@ -25,7 +25,7 @@ export interface Site extends Document {
     customPrice: string
     defaultPrice: string
     leads: Lead[]
-    transactions: Types.ObjectId[]
+    transactions: Array<Types.ObjectId|Transaction>
     dimensions: string
     area: string
 }
@@ -58,7 +58,7 @@ export const siteSchema = new Schema<Site>({
         },
     ],
     leads: [{ type: Schema.Types.ObjectId, ref: "Lead" }],
-    transactions: [{ type: Schema.Types.ObjectId, ref: "Transaction" }],
+    transactions: [{ type: Schema.Types.Mixed, ref: "Transaction" }],
 })
 
 const siteModel = mongoose.model("Site", siteSchema)

--- a/server/models/transaction.ts
+++ b/server/models/transaction.ts
@@ -2,11 +2,11 @@ import mongoose, { Schema, Types } from "mongoose"
 
 export let TRANSACTION_TYPES = ["TOKEN_GIVEN", "STATUS_CHANGE"]
 
-type StatusChangeMetadataType = {
+export type StatusChangeMetadataType = {
     prevStatus: string
     currentStatus: string
 }
-type TokenGivenMetadataType = {
+export type TokenGivenMetadataType = {
     token: string
 }
 
@@ -14,7 +14,7 @@ export interface Transaction {
     site: Types.ObjectId
     type: string
     date?: Date
-    metadata: Object
+    metadata: Record<string,any>
 }
 
 const transactionSchema = new Schema<Transaction & Document>({


### PR DESCRIPTION

- instead of `token:fwd23723423` , it will populate the token details
- sample response would be 
`
[
 {
    "metadata": {
      "prevStatus": "Available",
      "currentStatus": "Token"
    },
    "_id": "658abf1a3d7cffd41b0c815f",
    "site": "657d6c7e84d846d23423c786",
    "type": "STATUS_CHANGE",
    "date": "2023-12-26T11:54:21.376Z",
    "__v": 0
  },
  {
    "metadata": {
      "token": {
        "_id": "6582abd9f862fbacfc7515b7",
        "site": "657d19ab95ee05f9d7f3655b",
        "lead": {
          "_id": "6582aad94277c65db1f43598",
          "name": "prashanth",
          "phone": "909123123",
          "email": "prashanth@gmail.com",
          "buyerOffer": 4000,
          "sellerOffer": 3800,
          "finalPrice": 3500,
          "notes": "Will pay token on 25th",
          "status": "hot",
          "__v": 0
        },
        "tokenAmount": 123,
        "validity": 30,
        "createdAt": "2023-12-20T08:54:49.512Z",
        "updatedAt": "2023-12-20T08:54:49.512Z",
        "__v": 0
      }
    },
    "_id": "658abf1e3d7cffd41b0c8165",
    "site": "657d6c7e84d846d23423c786",
    "type": "TOKEN_GIVEN",
    "date": "2023-12-26T11:54:21.376Z",
    "__v": 0
  }
]
`